### PR TITLE
Use 'PreserveNewest' instead of 'Always' when copying files to output

### DIFF
--- a/Hammer.csproj
+++ b/Hammer.csproj
@@ -28,13 +28,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="Main.qml" CopyToPublishDirectory="Always" CopyToOutputDirectory="Always" />
-    <Content Include="Toast.qml" CopyToPublishDirectory="Always" CopyToOutputDirectory="Always" />
-    <Content Include="ToastManager.qml" CopyToPublishDirectory="Always" CopyToOutputDirectory="Always" />
-    <Content Include="StatusBox.qml" CopyToPublishDirectory="Always" CopyToOutputDirectory="Always" />
-    <Content Include="IssuesList.qml" CopyToPublishDirectory="Always" CopyToOutputDirectory="Always" />
-    <Content Include="assets/run-hammer.sh" CopyToPublishDirectory="Always" CopyToOutputDirectory="Always" />
-    <Content Include="assets/run-hammer.bat" CopyToPublishDirectory="Always" CopyToOutputDirectory="Always" />
+    <Content Include="Main.qml" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Toast.qml" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="ToastManager.qml" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="StatusBox.qml" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="IssuesList.qml" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="assets/run-hammer.sh" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="assets/run-hammer.bat" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Use 'PreserveNewest' instead of 'Always' when copying files to output
#### Motivation for adding to Hammer
Possibly quicker builds, though from what I've seen, it doesn't make a difference - output still says:

```
	Target _CopyOutOfDateSourceItemsToOutputDirectory:
		Building target "_CopyOutOfDateSourceItemsToOutputDirectory" partially, because some output files are out of date with respect to their input files.
		Copying file from "/home/vadi/Programs/Hammer/StatusBox.qml" to "/home/vadi/Programs/Hammer/bin/Debug/netcoreapp2.2/StatusBox.qml".
		Copying file from "/home/vadi/Programs/Hammer/assets/run-hammer.sh" to "/home/vadi/Programs/Hammer/bin/Debug/netcoreapp2.2/assets/run-hammer.sh".
		Copying file from "/home/vadi/Programs/Hammer/IssuesList.qml" to "/home/vadi/Programs/Hammer/bin/Debug/netcoreapp2.2/IssuesList.qml".
		Copying file from "/home/vadi/Programs/Hammer/Main.qml" to "/home/vadi/Programs/Hammer/bin/Debug/netcoreapp2.2/Main.qml".
		Copying file from "/home/vadi/Programs/Hammer/assets/run-hammer.bat" to "/home/vadi/Programs/Hammer/bin/Debug/netcoreapp2.2/assets/run-hammer.bat".
```
#### Other info (issues closed, discussion etc)
See https://docs.microsoft.com/en-us/visualstudio/msbuild/common-msbuild-project-items?view=vs-2019
