### PR TITLE
Fix message count (discussion)

### DIFF
--- a/IssuesList.qml
+++ b/IssuesList.qml
@@ -43,7 +43,7 @@ ColumnLayout {
                     return true
                 } else if (modelData.severity === "warning" && showWarnings.checked) {
                     return true
-                }  else if (modelData.severity === "informational" && showInfo.checked) {
+                }  else if (modelData.severity === "information" && showInfo.checked) {
                     return true
                 } else {
                     return false

--- a/Main.qml
+++ b/Main.qml
@@ -304,8 +304,8 @@ ApplicationWindow {
                     width: resultsPane.availableWidth/2
                     
                     runningStatus: appmodel.validatingDotnet
-                    errorCount:    appmodel.dotnetResult.errorCount
-                    warningCount:  appmodel.dotnetResult.warningCount
+                    errorCount:    appmodel.dotnetErrorCount
+                    warningCount:  appmodel.dotnetWarningCount
 
                     onClicked: errorsScrollView.contentItem.contentY = dotnetErrorList.y
                 }
@@ -316,8 +316,8 @@ ApplicationWindow {
                     width: resultsPane.availableWidth/2
 
                     runningStatus: appmodel.validatingJava
-                    errorCount:    appmodel.javaResult.errorCount
-                    warningCount:  appmodel.javaResult.warningCount
+                    errorCount:    appmodel.javaErrorCount
+                    warningCount:  appmodel.javaWarningCount
 
                     onClicked: errorsScrollView.contentItem.contentY = javaErrorList.y
                 }
@@ -351,16 +351,16 @@ ApplicationWindow {
                     IssuesList {
                         id: dotnetErrorList
                         label: ".NET"
-                        labelVisible: !appmodel.validatingDotnet && (appmodel.dotnetResult.errorCount >= 1 || appmodel.dotnetResult.warningCount >= 1)
-                        dataModel: if (!appmodel.validatingDotnet) Net.toListModel(appmodel.dotnetResult.issues)
+                        labelVisible: !appmodel.validatingDotnet && (appmodel.dotnetErrorCount >= 1 || appmodel.dotnetWarningCount >= 1)
+                        dataModel: if (!appmodel.validatingDotnet) Net.toListModel(appmodel.dotnetIssues)
                         onPeekIssue: parent.peekIssue(lineNumber, linePosition)
                     }
 
                     IssuesList {
                         id: javaErrorList
                         label: !appmodel.javaValidationCrashed ? "Java" : "Java (validation crashed, details below)"
-                        labelVisible: !appmodel.validatingJava && (appmodel.javaResult.errorCount >= 1 || appmodel.javaResult.warningCount >= 1)
-                        dataModel: if (!appmodel.validatingJava) Net.toListModel(appmodel.javaResult.issues)
+                        labelVisible: !appmodel.validatingJava && (appmodel.javaErrorCount >= 1 || appmodel.javaWarningCount >= 1)
+                        dataModel: if (!appmodel.validatingJava) Net.toListModel(appmodel.javaIssues)
                         onPeekIssue: parent.peekIssue(lineNumber, linePosition)
                     }
                 }

--- a/Program.cs
+++ b/Program.cs
@@ -499,9 +499,9 @@ class Program
 
       var validatorPath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location),
         "org.hl7.fhir.validator.jar");
-      var scopePath = ScopeDirectory;
+      var scopeArgument = string.IsNullOrEmpty(ScopeDirectory) ? "" :  $" -ig \"{ScopeDirectory}\"";
       var outputJson = $"{Path.GetTempFileName()}.json";
-      var finalArguments = $"-jar {validatorPath} -version 3.0 -tx \"{TerminologyService}\" -ig \"{scopePath}\" -output {outputJson} {resourcePath}";
+      var finalArguments = $"-jar {validatorPath} -version 3.0 -tx \"{TerminologyService}\"{scopeArgument} -output {outputJson} {resourcePath}";
 
 
       OperationOutcome result;


### PR DESCRIPTION
Hi Vadim, I noticed that the error/warning count wouldn't always get communicated to the QML side, and then I found your comment about setting the warning count before the error count. I believe your original approach with a general class that gets instantiated is not really compatible with the way Qt/QML signalling works, or at least stresses what it's supposed to do.
Since the ValidationResult is a really simple structure with three elements that gets used just twice, maybe it is best just to write these six resulting elements out directly, like below. This works reliably.
Another approach that works is to first instantiate a new ValidationResult, then set its properties and then bind it to the property that QML can access. But this doesn't allow for changing properties of this object afterwards in any reliable way. Alternatively, you can expand it with explicit signals, but that makes things quite complicated.