### PR TITLE
Fix .NET status box to display # of errors as soon as validation is done

### DIFF
--- a/StatusBox.qml
+++ b/StatusBox.qml
@@ -1,14 +1,14 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.5
 
-/** A 'dashboard' display box for reporting an overview of the failure or succes of a validation step. */ 
+/** A 'dashboard' display box for reporting an overview of the failure or succes of a validation step. */
 Item {
     property string label          /** Label to show underneath the box */
     property bool   runningStatus  /** Set this to indicate if the validation is running */
     property int    errorCount     /** Set this to the number of errors during validation */
     property int    warningCount   /** Set this to the number of warnings during valudation */
 
-    /** Activated whenever the box is clicked. */ 
+    /** Activated whenever the box is clicked. */
     signal clicked()
     signal rightClicked()
 
@@ -66,7 +66,7 @@ Item {
             text: qsTr(`${errorCount} ∙ ${warningCount}`)
             font.pointSize: 35
             anchors.centerIn: parent
-            visible: !appmodel.validatingJava
+            visible: !runningStatus
             color: "white"
 
 
@@ -80,7 +80,7 @@ Item {
             }
         }
     }
-    
+
     Label {
         text: label
         anchors.horizontalCenter: mainErrorsRectangle.horizontalCenter


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix .NET status box to display # of errors as soon as validation is done
#### Motivation for adding to Hammer
Less bugs
#### Other info (issues closed, discussion etc)
Fix https://github.com/health-validator/Hammer/issues/96