### PR TITLE
Refactor settings pane into its own component

### DIFF
--- a/IssuesList.qml
+++ b/IssuesList.qml
@@ -8,6 +8,9 @@ ColumnLayout {
     property string label        /** The label for the current collection of messages */
     property bool   labelVisible /** Set this to indicate if the label should be visible */
     property var    dataModel    /** Set this to the datamodel from the C# side */
+    property bool   showErrors   /** Show messages with severity 'error' or 'fatal' */
+    property bool   showWarnings /** Show messages with severity 'warning' */
+    property bool   showshowInfo /** Show messages with severity 'informational' */
 
     anchors.left: parent.left
     anchors.right: parent.right
@@ -43,11 +46,11 @@ ColumnLayout {
             property int rightMargin: 15
 
             visible: {
-                if (modelData.severity === "error" && settings.showErrors.checked) {
+                if (modelData.severity === "error" && showErrors) {
                     return true
-                } else if (modelData.severity === "warning" && settings.showWarnings.checked) {
+                } else if (modelData.severity === "warning" && showWarnings) {
                     return true
-                }  else if (modelData.severity === "information" && settings.showInfo.checked) {
+                }  else if (modelData.severity === "information" && showInfo) {
                     return true
                 } else {
                     return false

--- a/IssuesList.qml
+++ b/IssuesList.qml
@@ -43,11 +43,11 @@ ColumnLayout {
             property int rightMargin: 15
 
             visible: {
-                if (modelData.severity === "error" && showErrors.checked) {
+                if (modelData.severity === "error" && settings.showErrors.checked) {
                     return true
-                } else if (modelData.severity === "warning" && showWarnings.checked) {
+                } else if (modelData.severity === "warning" && settings.showWarnings.checked) {
                     return true
-                }  else if (modelData.severity === "information" && showInfo.checked) {
+                }  else if (modelData.severity === "information" && settings.showInfo.checked) {
                     return true
                 } else {
                     return false

--- a/Main.qml
+++ b/Main.qml
@@ -302,7 +302,7 @@ ApplicationWindow {
                     id: dotnetErrorsBox
                     label: ".NET"
                     width: resultsPane.availableWidth/2
-                    
+
                     runningStatus: appmodel.validatingDotnet
                     errorCount:    appmodel.dotnetErrorCount
                     warningCount:  appmodel.dotnetWarningCount
@@ -330,7 +330,7 @@ ApplicationWindow {
                 Layout.fillHeight: true
                 Layout.fillWidth: true
                 clip: true
-                
+
                 contentWidth: parent.width
                 contentHeight: errorsRepeaterColumn.height
 
@@ -357,6 +357,9 @@ ApplicationWindow {
                         dataModel: if (!appmodel.validatingDotnet) Net.toListModel(appmodel.dotnetIssues)
                         onPeekIssue: parent.peekIssue(lineNumber, linePosition)
                         onRightClicked: resultsPane.openContextMenu()
+                        showErrors: settings.showErrors.checked
+                        showWarnings: settings.showWarnings.checked
+                        showshowInfo: settings.showInfo.checked
                     }
 
                     IssuesList {
@@ -366,6 +369,9 @@ ApplicationWindow {
                         dataModel: if (!appmodel.validatingJava) Net.toListModel(appmodel.javaIssues)
                         onPeekIssue: parent.peekIssue(lineNumber, linePosition)
                         onRightClicked: resultsPane.openContextMenu()
+                        showErrors: settings.showErrors.checked
+                        showWarnings: settings.showWarnings.checked
+                        showshowInfo: settings.showInfo.checked
                     }
                 }
             }

--- a/Main.qml
+++ b/Main.qml
@@ -14,7 +14,7 @@ ApplicationWindow {
     minimumWidth: 550; minimumHeight: 300
     title: qsTr("Hammer STU3 (experimental)")
 
-    Universal.theme: darkAppearanceSwitch.checked ? Universal.Dark : Universal.Light
+    Universal.theme: settings.darkAppearanceSwitch.checked ? Universal.Dark : Universal.Light
 
     property int tooltipDelay: 1500
     property int animationDuration: appmodel.animateQml ? 1000 : 0
@@ -184,19 +184,19 @@ ApplicationWindow {
                 name: "ENTERING_RESOURCE"
                 PropertyChanges { target: addResourcesPage; x: 0 }
                 PropertyChanges { target: resultsPane; x: resultsPane.width }
-                PropertyChanges { target: settingsPane; y: window.height }
+                PropertyChanges { target: settings; y: window.height }
                 PropertyChanges { target: actionButton; text: appmodel.validateButtonText }
             },
             State {
                 name: "VALIDATION_RESULTS"
                 PropertyChanges { target: addResourcesPage; x: addResourcesPage.width * -1 }
                 PropertyChanges { target: resultsPane; x: 0 }
-                PropertyChanges { target: settingsPane; y: window.height }
+                PropertyChanges { target: settings; y: window.height }
                 PropertyChanges { target: actionButton; text: qsTr("⮪ Back")}
             },
             State {
                 name: "EDITING_SETTINGS"
-                PropertyChanges { target: settingsPane; y: 0 }
+                PropertyChanges { target: settings; y: 0 }
                 PropertyChanges { target: actionButton; text: qsTr("⮪ Back")}
             }
         ]
@@ -404,107 +404,13 @@ ApplicationWindow {
         }
     }
 
-    Pane {
-        id: settingsPane
-        height: addResourcesPage.height; width: addResourcesPage.width
-        x: 0; y: window.height
+    SettingsPane {
+        id: settings
+        height: addResourcesPage.height
         horizontalPadding: 40
-
-        property int headerFontSize: 14
-
-        GridLayout {
-            id: grid
-            columns: 3
-            anchors.fill: parent
-            rowSpacing: 10
-
-            Text {
-                text: qsTr("Scope")
-                color: Universal.foreground
-                font.pointSize: settingsPane.headerFontSize
-                font.bold: true
-
-                Layout.columnSpan: 3
-
-                ToolTip.visible: scopeMouseArea.containsMouse
-                ToolTip.text: qsTr("The scope (context) that this resource should be validated in.\nCurrently only folders are considered - packages are coming soon")
-
-                MouseArea {
-                    id: scopeMouseArea; hoverEnabled: true; anchors.fill: parent
-                }
-            }
-            TextField {
-                text: appmodel.scopeDirectory
-                onTextChanged: appmodel.loadScopeDirectory(text)
-                selectByMouse: true
-                placeholderText: qsTr("Current scope: none")
-                Layout.columnSpan: 2
-                Layout.fillWidth: true
-            }
-            Button {
-                text: "<center>Browse...</center>"
-                onClicked: scopePicker.open()
-
-                FolderDialog {
-                    id: scopePicker
-                    title: "Folder to act as the scope (context) for validation"
-                    folder: appmodel.scopeDirectory ? "file://" + appmodel.scopeDirectory : StandardPaths.standardLocations(StandardPaths.DesktopLocation)[0]
-                    onAccepted: appmodel.loadScopeDirectory(scopePicker.folder)
-                }
-            }
-
-            Text {
-                text: qsTr("Show me")
-                color: Universal.foreground
-                font.pointSize: settingsPane.headerFontSize
-                font.bold: true
-                Layout.fillWidth: true; Layout.columnSpan: 3
-                topPadding: 10
-            }
-            RowLayout {
-                Layout.columnSpan: 3
-                CheckBox {
-                    id: showErrors
-                    text: qsTr("Errors")
-                    checked: true
-                    Layout.fillWidth: true
-                }
-                CheckBox {
-                    id: showWarnings
-                    text: qsTr("Warnings")
-                    checked: true
-                    Layout.fillWidth: true
-                }
-                CheckBox {
-                    id: showInfo
-                    text: qsTr("Info")
-                    checked: true
-                    Layout.fillWidth: true
-                }
-            }
-
-            Text {
-                text: qsTr("Appearance")
-                color: Universal.foreground
-                font.pointSize: settingsPane.headerFontSize
-                font.bold: true
-                Layout.fillWidth: true
-                Layout.columnSpan: 3
-                topPadding: 10
-            }
-
-            Switch {
-                id: darkAppearanceSwitch
-                text: qsTr("Dark")
-            }
-
-            Item {
-                id: spanner
-                Layout.columnSpan: 3
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-            }
-        }
+        width: addResourcesPage.width
+        x: 0
+        y: window.height
     }
 }
 

--- a/SettingsPane.qml
+++ b/SettingsPane.qml
@@ -1,0 +1,111 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import appmodel 1.0
+import QtQuick.Controls.Universal 2.12
+import QtQuick.Layouts 1.12
+import Qt.labs.platform 1.1
+
+Pane {
+    id: settingsPane
+
+    property Switch darkAppearanceSwitch: darkAppearanceSwitch
+    property CheckBox showErrors: showErrors
+    property CheckBox showWarnings: showWarnings
+    property CheckBox showInfo: showInfo
+
+    readonly property int headerFontSize: 14
+
+    GridLayout {
+        id: grid
+        columns: 3
+        anchors.fill: parent
+        rowSpacing: 10
+
+        Text {
+            text: qsTr("Scope")
+            color: Universal.foreground
+            font.pointSize: settingsPane.headerFontSize
+            font.bold: true
+
+            Layout.columnSpan: 3
+
+            ToolTip.visible: scopeMouseArea.containsMouse
+            ToolTip.text: qsTr("The scope (context) that this resource should be validated in.\nCurrently only folders are considered - packages are coming soon")
+
+            MouseArea {
+                id: scopeMouseArea; hoverEnabled: true; anchors.fill: parent
+            }
+        }
+        TextField {
+            text: appmodel.scopeDirectory
+            onTextChanged: appmodel.loadScopeDirectory(text)
+            selectByMouse: true
+            placeholderText: qsTr("Current scope: none")
+            Layout.columnSpan: 2
+            Layout.fillWidth: true
+        }
+        Button {
+            text: "<center>Browse...</center>"
+            onClicked: scopePicker.open()
+
+            FolderDialog {
+                id: scopePicker
+                title: "Folder to act as the scope (context) for validation"
+                folder: appmodel.scopeDirectory ? "file://" + appmodel.scopeDirectory : StandardPaths.standardLocations(StandardPaths.DesktopLocation)[0]
+                onAccepted: appmodel.loadScopeDirectory(scopePicker.folder)
+            }
+        }
+
+        Text {
+            text: qsTr("Show me")
+            color: Universal.foreground
+            font.pointSize: settingsPane.headerFontSize
+            font.bold: true
+            Layout.fillWidth: true; Layout.columnSpan: 3
+            topPadding: 10
+        }
+        RowLayout {
+            Layout.columnSpan: 3
+            CheckBox {
+                id: showErrors
+                text: qsTr("Errors")
+                checked: true
+                Layout.fillWidth: true
+            }
+            CheckBox {
+                id: showWarnings
+                text: qsTr("Warnings")
+                checked: true
+                Layout.fillWidth: true
+            }
+            CheckBox {
+                id: showInfo
+                text: qsTr("Info")
+                checked: true
+                Layout.fillWidth: true
+            }
+        }
+
+        Text {
+            text: qsTr("Appearance")
+            color: Universal.foreground
+            font.pointSize: settingsPane.headerFontSize
+            font.bold: true
+            Layout.fillWidth: true
+            Layout.columnSpan: 3
+            topPadding: 10
+        }
+
+        Switch {
+            id: darkAppearanceSwitch
+            text: qsTr("Dark")
+        }
+
+        Item {
+            id: spanner
+            Layout.columnSpan: 3
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+    }
+}


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Refactor settings pane into its own component
#### Motivation for adding to Hammer
Less crammed `Main.qml`
#### Other info (issues closed, discussion etc)
Qt Creator's refactoring function here worked great!

Having settings in an explicit `settings` instance might also make it easier to use QML's QSettings support.