### PR TITLE
Don't explicitely export counts? (discussion)

### DIFF
--- a/IssuesList.qml
+++ b/IssuesList.qml
@@ -6,7 +6,6 @@ import QtQuick.Layouts 1.12
 ColumnLayout {
     id: rootComponent
     property string label        /** The label for the current collection of messages */
-    property bool   labelVisible /** Set this to indicate if the label should be visible */
     property var    dataModel    /** Set this to the datamodel from the C# side */
     property bool   showErrors   /** Show messages with severity 'error' or 'fatal' */
     property bool   showWarnings /** Show messages with severity 'warning' */
@@ -23,7 +22,7 @@ ColumnLayout {
         Layout.alignment: Qt.AlignCenter
         color: "#696969"
         font.pointSize: 17
-        visible: labelVisible
+        visible: messagesRepeater.count > 0
     }
 
     Repeater {

--- a/IssuesList.qml
+++ b/IssuesList.qml
@@ -9,7 +9,7 @@ ColumnLayout {
     property var    dataModel    /** Set this to the datamodel from the C# side */
     property bool   showErrors   /** Show messages with severity 'error' or 'fatal' */
     property bool   showWarnings /** Show messages with severity 'warning' */
-    property bool   showshowInfo /** Show messages with severity 'informational' */
+    property bool   showInfo     /** Show messages with severity 'informational' */
 
     anchors.left: parent.left
     anchors.right: parent.right

--- a/Main.qml
+++ b/Main.qml
@@ -295,8 +295,7 @@ ApplicationWindow {
                     width: resultsPane.availableWidth/2
 
                     runningStatus: appmodel.validatingDotnet
-                    errorCount:    appmodel.dotnetErrorCount
-                    warningCount:  appmodel.dotnetWarningCount
+                    dataModel: if (!appmodel.validatingDotnet) Net.toListModel(appmodel.dotnetIssues)
 
                     onClicked: errorsScrollView.contentItem.contentY = dotnetErrorList.y
                     onRightClicked: if (!appmodel.validatingDotnet) resultsPane.openContextMenu()
@@ -308,8 +307,7 @@ ApplicationWindow {
                     width: resultsPane.availableWidth/2
 
                     runningStatus: appmodel.validatingJava
-                    errorCount:    appmodel.javaErrorCount
-                    warningCount:  appmodel.javaWarningCount
+                    dataModel: if (!appmodel.validatingJava) Net.toListModel(appmodel.javaIssues)
 
                     onClicked: errorsScrollView.contentItem.contentY = javaErrorList.y
                     onRightClicked: if (!appmodel.validatingJava) resultsPane.openContextMenu()
@@ -344,25 +342,23 @@ ApplicationWindow {
                     IssuesList {
                         id: dotnetErrorList
                         label: ".NET"
-                        labelVisible: !appmodel.validatingDotnet && (appmodel.dotnetErrorCount >= 1 || appmodel.dotnetWarningCount >= 1)
                         dataModel: if (!appmodel.validatingDotnet) Net.toListModel(appmodel.dotnetIssues)
                         onPeekIssue: parent.peekIssue(lineNumber, linePosition)
                         onRightClicked: resultsPane.openContextMenu()
                         showErrors: settings.showErrors.checked
                         showWarnings: settings.showWarnings.checked
-                        showshowInfo: settings.showInfo.checked
+                        showInfo: settings.showInfo.checked
                     }
 
                     IssuesList {
                         id: javaErrorList
                         label: !appmodel.javaValidationCrashed ? "Java" : "Java (validation crashed, details below)"
-                        labelVisible: !appmodel.validatingJava && (appmodel.javaErrorCount >= 1 || appmodel.javaWarningCount >= 1)
                         dataModel: if (!appmodel.validatingJava) Net.toListModel(appmodel.javaIssues)
                         onPeekIssue: parent.peekIssue(lineNumber, linePosition)
                         onRightClicked: resultsPane.openContextMenu()
                         showErrors: settings.showErrors.checked
                         showWarnings: settings.showWarnings.checked
-                        showshowInfo: settings.showInfo.checked
+                        showInfo: settings.showInfo.checked
                     }
                 }
             }

--- a/Main.qml
+++ b/Main.qml
@@ -296,6 +296,9 @@ ApplicationWindow {
 
                     runningStatus: appmodel.validatingDotnet
                     dataModel: if (!appmodel.validatingDotnet) Net.toListModel(appmodel.dotnetIssues)
+                    showErrors: settings.showErrors.checked
+                    showWarnings: settings.showWarnings.checked
+                    showInfo: settings.showInfo.checked
 
                     onClicked: errorsScrollView.contentItem.contentY = dotnetErrorList.y
                     onRightClicked: if (!appmodel.validatingDotnet) resultsPane.openContextMenu()
@@ -308,6 +311,9 @@ ApplicationWindow {
 
                     runningStatus: appmodel.validatingJava
                     dataModel: if (!appmodel.validatingJava) Net.toListModel(appmodel.javaIssues)
+                    showErrors: settings.showErrors.checked
+                    showWarnings: settings.showWarnings.checked
+                    showInfo: settings.showInfo.checked
 
                     onClicked: errorsScrollView.contentItem.contentY = javaErrorList.y
                     onRightClicked: if (!appmodel.validatingJava) resultsPane.openContextMenu()

--- a/Program.cs
+++ b/Program.cs
@@ -157,20 +157,6 @@ class Program
       set => this.SetProperty(ref _validatingJava, value);
     }
 
-    private int _javaErrorCount;
-    [NotifySignal]
-    public int JavaErrorCount {
-      get => _javaErrorCount;
-      set => this.SetProperty(ref _javaErrorCount, value);
-    }
-
-    private int _javaWarningCount;
-    [NotifySignal]
-    public int JavaWarningCount {
-      get => _javaWarningCount;
-      set => this.SetProperty(ref _javaWarningCount, value);
-    }
-
     private List<Issue> _javaIssues = new List<Issue>();
     [NotifySignal]
     public List<Issue> JavaIssues {
@@ -178,20 +164,6 @@ class Program
       set => this.SetProperty(ref _javaIssues, value);
     }
 
-    private int _dotnetErrorCount;
-    [NotifySignal]
-    public int DotnetErrorCount {
-      get => _dotnetErrorCount;
-      set => this.SetProperty(ref _dotnetErrorCount, value);
-    }
-
-    private int _dotnetWarningCount;
-    [NotifySignal]
-    public int DotnetWarningCount {
-      get => _dotnetWarningCount;
-      set => this.SetProperty(ref _dotnetWarningCount, value);
-    }
-    
     private List<Issue> _dotnetIssues = new List<Issue>();
     [NotifySignal]
     public List<Issue> DotnetIssues {
@@ -240,38 +212,9 @@ class Program
 
     private void ResetResults()
     {
-      JavaErrorCount     = 0;
-      JavaWarningCount   = 0;
       JavaIssues         = new List<Issue>();
-      DotnetErrorCount   = 0;
-      DotnetWarningCount = 0;
       DotnetIssues       = new List<Issue>();
       JavaValidationCrashed = false;
-    }
-
-    private void SetOutcome(OperationOutcome outcome, ValidatorType type)
-    {
-      if (type == ValidatorType.Java) {
-        JavaResult = new ValidationResult
-        {
-          ValidatorType = type,
-          Issues = convertIssues(outcome.Issue),
-          WarningCount = outcome.Warnings,
-          ErrorCount = outcome.Errors + outcome.Fatals
-        };
-        // warnings have to be set before errors for some reason, otherwise not transferred to QML
-      } else {
-        DotnetResult = new ValidationResult
-        {
-          ValidatorType = type,
-          Issues = convertIssues(outcome.Issue),
-          WarningCount = outcome.Warnings,
-          ErrorCount = outcome.Errors + outcome.Fatals
-        };
-        // warnings have to be set before errors for some reason, otherwise not transferred to QML
-      }
-
-      // Console.WriteLine(outcome.ToString());
     }
 
     public enum ValidatorType { Dotnet = 1, Java = 2 }
@@ -762,20 +705,14 @@ class Program
           {
             allTasks.Remove(validateWithJava);
             var result = await validateWithJava;
-            JavaErrorCount   = result.Errors + result.Fatals;
-            JavaWarningCount = result.Warnings;
             JavaIssues       = convertIssues(result.Issue);
-            SetOutcome(result, ValidatorType.Java);
             ValidatingJava = false;
           }
           else if (finished == validateWithDotnet)
           {
             allTasks.Remove(validateWithDotnet);
             var result = await validateWithDotnet;
-            DotnetErrorCount   = result.Errors + result.Fatals;
-            DotnetWarningCount = result.Warnings;
             DotnetIssues       = convertIssues(result.Issue);
-            SetOutcome(result, ValidatorType.Dotnet);
             ValidatingDotnet = false;
           }
           else

--- a/StatusBox.qml
+++ b/StatusBox.qml
@@ -5,8 +5,28 @@ import QtQuick.Controls 2.5
 Item {
     property string label          /** Label to show underneath the box */
     property bool   runningStatus  /** Set this to indicate if the validation is running */
-    property int    errorCount     /** Set this to the number of errors during validation */
-    property int    warningCount   /** Set this to the number of warnings during valudation */
+    property var    dataModel
+    
+    property int    errorCount
+    property int    warningCount
+    property int    infoCount
+
+    onDataModelChanged: {
+        var error = 0
+        var warning = 0
+        var info = 0
+
+        for (var i = 0; i < dataModel.rowCount(); i++) {
+            var severity = dataModel.data(dataModel.index(i, 0)).severity
+            if (severity == "information") info++
+            else if (severity == "warning") warning++
+            else if (severity == "error" | severity == "fatal") error++
+        }
+
+        errorCount = error
+        warningCount = warning
+        infoCount = info
+    }
 
     /** Activated whenever the box is clicked. */
     signal clicked()


### PR DESCRIPTION
Hi Vadim, I'd like you opinion on this. The C# side now exports the list of issues for both validators, and in addition counts for each class of issues (except info messages, but I want to add that as well). This seems 'double', as that info is already contained in the list of issues, and it can be extracted in QML with a bit of JS, which is demonstrated in this PR (it's not finished yet, just a demo for this approach).
This of course has the downside that we're adding imperative JS in QML, but makes the public interface much cleaner and the declaring QML parts (in Main.qml) more concise.
So, what do you think?
