### PR TITLE
Fix pre-release uploads

### DIFF
--- a/.github/workflows/build-hammer.yml
+++ b/.github/workflows/build-hammer.yml
@@ -118,6 +118,7 @@ jobs:
       with:
         repo_token: ${{secrets.GITHUB_TOKEN}}
         prerelease: true
+        automatic_release_tag: latest
         title: Latest in-development build
         files: |
           artifacts/hammer-linux/Hammer-linux.zip


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix pre-release uploads
#### Motivation for adding to Hammer
Fix:

>   Error: The parameter "automatic_release_tag" was not set and this does not appear to be a GitHub tag event. (Event: refs/heads/main)
#### Other info (issues closed, discussion etc)
