### PR TITLE
Add .NET trimming member-level trimming

### DIFF
--- a/Hammer.csproj
+++ b/Hammer.csproj
@@ -27,19 +27,24 @@
     <SelfContained>true</SelfContained>
     <!-- single file does not work: https://github.com/qmlnet/qmlnet/issues/238 -->
     <PublishSingleFile>false</PublishSingleFile>
-    <!-- <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract> -->
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>CopyUsed</TrimMode>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) and '$(Configuration)' == 'Release'">
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>CopyUsed</TrimMode>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) and '$(Configuration)' == 'Release'">
     <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>CopyUsed</TrimMode>
   </PropertyGroup>
 
   <Target Name="AddPackageAliases" BeforeTargets="ResolveReferences" Outputs="%(PackageReference.Identity)">

--- a/Hammer.csproj
+++ b/Hammer.csproj
@@ -28,7 +28,7 @@
     <!-- single file does not work: https://github.com/qmlnet/qmlnet/issues/238 -->
     <PublishSingleFile>false</PublishSingleFile>
     <PublishTrimmed>true</PublishTrimmed>
-    <TrimMode>CopyUsed</TrimMode>
+    <TrimMode>Link</TrimMode>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) and '$(Configuration)' == 'Release'">
@@ -36,7 +36,7 @@
     <SelfContained>true</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>
     <PublishTrimmed>true</PublishTrimmed>
-    <TrimMode>CopyUsed</TrimMode>
+    <TrimMode>Link</TrimMode>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) and '$(Configuration)' == 'Release'">
@@ -44,7 +44,7 @@
     <SelfContained>true</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>
     <PublishTrimmed>true</PublishTrimmed>
-    <TrimMode>CopyUsed</TrimMode>
+    <TrimMode>Link</TrimMode>
   </PropertyGroup>
 
   <Target Name="AddPackageAliases" BeforeTargets="ResolveReferences" Outputs="%(PackageReference.Identity)">


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add .NET trimming.

175MB Hammer-linux-no-trimming.zip
160MB hammer-linux-assembly.zip | works.
156MB hammer-linux-member.zip | works.

161MB Hammer-windows-no-trimming.zip
147MB hammer-windows-assembly.zip | works.
142MB hammer-windows-member.zip | works.

#### Motivation for adding to Hammer
Smaller release sizes
#### Other info (issues closed, discussion etc)
Close https://github.com/health-validator/Hammer/issues/348