### PR TITLE
Remove macOS terminal window

### DIFF
--- a/Hammer.csproj
+++ b/Hammer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -39,7 +39,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) and '$(Configuration)' == 'Release'">
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Try removing macOS terminal window with 'WinExe'
#### Motivation for adding to Hammer
So Hammer on macOS doesn't open a corresponding terminal window when launched.
#### Other info (issues closed, discussion etc)
Fix https://github.com/health-validator/Hammer/issues/385, see https://github.com/dotnet/runtime/issues/52813 for context.