### PR TITLE
Add installation as a dotnet tool

### DIFF
--- a/.github/workflows/build-hammer.yml
+++ b/.github/workflows/build-hammer.yml
@@ -70,6 +70,8 @@ jobs:
         echo "Git revision of the validator code: $(git rev-parse HEAD)"
         mvn package -Dmaven.test.skip=true --projects org.hl7.fhir.validation.cli --no-transfer-progress
         mv org.hl7.fhir.validation.cli/target/org.hl7.fhir.validation.cli*-SNAPSHOT.jar $GITHUB_WORKSPACE/org.hl7.fhir.validator.jar
+
+        # validate Java validator works
         cd $GITHUB_WORKSPACE
         java -jar org.hl7.fhir.validator.jar
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -62,6 +62,8 @@ jobs:
         echo "Git revision of the validator code: $(git rev-parse HEAD)"
         mvn package -Dmaven.test.skip=true --projects org.hl7.fhir.validation.cli --no-transfer-progress
         mv org.hl7.fhir.validation.cli/target/org.hl7.fhir.validation.cli*-SNAPSHOT.jar $GITHUB_WORKSPACE/org.hl7.fhir.validator.jar
+
+        # validate Java validator works
         cd $GITHUB_WORKSPACE
         java -jar org.hl7.fhir.validator.jar
 
@@ -178,6 +180,13 @@ jobs:
         asset_path: ${{env.RELEASEDIR}}\Setup.exe
         asset_content_type: application/vnd.microsoft.portable-executable
 
-    - name: Setup tmate session
+    - name: Publish to nuget
+      env:
+        NUGET_API_KEY: ${{secrets.NUGET_API_KEY}}
+      shell: bash
+        ./create-package.sh
+        dotnet nuget push nupkg/Hammer.${{env.SHORT_TAG_NAME}}.nupkg --api-key ${{env.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+
+    - name: Setup tmate session should the build fail
       if: ${{ failure() }}
       uses: mxschmitt/action-tmate@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Customizations
 nupkg/
-qt-runtime-linux/
+qt-runtime-*/
 qt-runtime-*.tar.gz
 
 # Standard template

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Customizations
 nupkg/
+qt-runtime/
+qt-runtime.tar.gz
 
 # Standard template
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Customizations
+nupkg/
+
+# Standard template
+
 *.pdb
 *.code-workspace
 *.qml.autosave

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Customizations
 nupkg/
-qt-runtime/
+qt-runtime-linux/
 qt-runtime.tar.gz
 
 # Standard template

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Customizations
 nupkg/
 qt-runtime-linux/
-qt-runtime.tar.gz
+qt-runtime-*.tar.gz
 
 # Standard template
 

--- a/Hammer.csproj
+++ b/Hammer.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <PackageId>Hammer</PackageId>
-    <IsPackable>false</IsPackable>
     <Version>0.0.3</Version>
     <Authors>Vadim Peretokin</Authors>
     <Description>A modern, cross-platform GUI validator for FHIR®.</Description>
@@ -120,7 +119,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- <Content Include="org.hl7.fhir.validator.jar" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" /> -->
+    <Content Include="org.hl7.fhir.validator.jar" CopyToOutputDirectory="PreserveNewest">
+      <PackagePath></PackagePath>
+    </Content>
     <Content Include="assets/examples/*" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="*.qml" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="assets/run-hammer.sh" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
@@ -132,7 +133,7 @@
     <!-- better to use our own instead of the nuget package, see https://github.com/qmlnet/qmlnet/issues/241#issuecomment-879359840 -->
     <Content Include="qt-runtime-linux/**/*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PackagePath>content/qt-runtime-linux</PackagePath>
+      <PackagePath></PackagePath>
     </Content>
   </ItemGroup>
 

--- a/Hammer.csproj
+++ b/Hammer.csproj
@@ -13,6 +13,9 @@
     <PackageIconUrl>https://github.com/health-validator/Hammer/raw/master/assets/hammer-logo.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/health-validator/Hammer</RepositoryUrl>
     <PackageTags>validator, fhir, xml, json, crossplatform</PackageTags>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>hammer</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Hammer.csproj
+++ b/Hammer.csproj
@@ -119,22 +119,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="org.hl7.fhir.validator.jar" CopyToOutputDirectory="PreserveNewest">
-      <PackagePath></PackagePath>
-    </Content>
-    <Content Include="assets/examples/*" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="*.qml" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="assets/run-hammer.sh" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="assets/run-hammer.bat" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="org.hl7.fhir.validator.jar" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="assets/examples/*" CopyToPublishDirectory="PreserveNewest" />
+    <None Update="*.qml" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="assets/run-hammer.sh" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="assets/run-hammer.bat" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <None Include="assets/hammer-logo.png" Pack="true" PackagePath="\"/>
-    <Content Include="assets/fonts/RobotoCondensed-Regular.ttf" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="RobotoMono-Regular.ttf" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="assets/fonts/RobotoCondensed-Regular.ttf" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="RobotoMono-Regular.ttf" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
 
     <!-- better to use our own instead of the nuget package, see https://github.com/qmlnet/qmlnet/issues/241#issuecomment-879359840 -->
-    <Content Include="qt-runtime-linux/**/*.*">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PackagePath></PackagePath>
-    </Content>
+    <None Update="qt-runtime-linux/**/*.*"  CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <!-- doesn't work - file included in package does not have the change -->

--- a/Hammer.csproj
+++ b/Hammer.csproj
@@ -129,7 +129,9 @@
     <None Update="RobotoMono-Regular.ttf" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
 
     <!-- better to use our own instead of the nuget package, see https://github.com/qmlnet/qmlnet/issues/241#issuecomment-879359840 -->
-    <None Update="qt-runtime-linux/**/*.*"  CopyToOutputDirectory="PreserveNewest" />
+    <None Update="qt-runtime-linux/**/*.*" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="qt-runtime-osx/**/*.*" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="qt-runtime-win/**/*.*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <!-- doesn't work - file included in package does not have the change -->

--- a/Hammer.csproj
+++ b/Hammer.csproj
@@ -6,7 +6,7 @@
     <PackageId>Hammer</PackageId>
     <Version>0.0.3</Version>
     <Authors>Vadim Peretokin</Authors>
-    <Description>A modern, cross-platform GUI validator for FHIR®.</Description>
+    <Description>A modern, cross-platform validator for FHIR® resources.</Description>
     <PackageProjectUrl>https://github.com/health-validator/Hammer</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>hammer-logo.png</PackageIcon>
@@ -17,6 +17,7 @@
     <IsPackable>true</IsPackable>
     <ToolCommandName>hammer</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
@@ -120,13 +121,14 @@
 
   <ItemGroup>
     <None Update="org.hl7.fhir.validator.jar" CopyToOutputDirectory="PreserveNewest" />
-    <None Update="assets/examples/*" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="assets/examples/*" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <None Update="*.qml" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <None Update="assets/run-hammer.sh" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <None Update="assets/run-hammer.bat" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <None Include="assets/hammer-logo.png" Pack="true" PackagePath="\"/>
     <None Update="assets/fonts/RobotoCondensed-Regular.ttf" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <None Update="RobotoMono-Regular.ttf" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <!-- doesn't work - file included in package does not have the change -->

--- a/Hammer.csproj
+++ b/Hammer.csproj
@@ -3,17 +3,19 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <PackageId>Hammer.Validator</PackageId>
+    <PackageId>Hammer</PackageId>
     <IsPackable>false</IsPackable>
     <Version>0.0.2</Version>
     <Authors>Vadim Peretokin</Authors>
-    <Description>A modern, cross-platform validator for FHIR®.</Description>
+    <Description>A modern, cross-platform GUI validator for FHIR®.</Description>
     <PackageProjectUrl>https://github.com/health-validator/Hammer</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/health-validator/Hammer/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageIcon>hammer-logo.png</PackageIcon>
     <PackageIconUrl>https://github.com/health-validator/Hammer/raw/master/assets/hammer-logo.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/health-validator/Hammer</RepositoryUrl>
     <PackageTags>validator, fhir, xml, json, crossplatform</PackageTags>
     <PackAsTool>true</PackAsTool>
+    <IsPackable>true</IsPackable>
     <ToolCommandName>hammer</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
   </PropertyGroup>
@@ -118,13 +120,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- only copy on release because the file is already present then. Couldn't get msbuild to download on its own -->
-    <Content Include="org.hl7.fhir.validator.jar" Condition=" '$(Configuration)' == 'Release' " CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="org.hl7.fhir.validator.jar" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="assets/examples/*" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="*.qml" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="assets/run-hammer.sh" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="assets/run-hammer.bat" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="assets/hammer-logo.png" Pack="true" PackagePath="\"/>
     <Content Include="assets/fonts/RobotoCondensed-Regular.ttf" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="RobotoMono-Regular.ttf" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
+  <!-- doesn't work - file included in package does not have the change -->
+  <Target Name="PrepQmlForPacking" AfterTargets="PublishBuild" BeforeTargets="GenerateNuspec">
+    <Exec Command="sed -i 's|// import appmodel 1.0|import appmodel 1.0|g' $(PublishDir)/Main.qml" />
+  </Target>
 </Project>

--- a/Hammer.csproj
+++ b/Hammer.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <PackageId>Hammer</PackageId>
     <IsPackable>false</IsPackable>
-    <Version>0.0.2</Version>
+    <Version>0.0.3</Version>
     <Authors>Vadim Peretokin</Authors>
     <Description>A modern, cross-platform GUI validator for FHIR®.</Description>
     <PackageProjectUrl>https://github.com/health-validator/Hammer</PackageProjectUrl>
@@ -120,7 +120,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="org.hl7.fhir.validator.jar" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
+    <!-- <Content Include="org.hl7.fhir.validator.jar" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" /> -->
     <Content Include="assets/examples/*" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="*.qml" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="assets/run-hammer.sh" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
@@ -128,11 +128,13 @@
     <None Include="assets/hammer-logo.png" Pack="true" PackagePath="\"/>
     <Content Include="assets/fonts/RobotoCondensed-Regular.ttf" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="RobotoMono-Regular.ttf" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
 
-  <Content Include="qt-runtime/**/*.*">
-    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-  </Content>
+    <!-- better to use our own instead of the nuget package, see https://github.com/qmlnet/qmlnet/issues/241#issuecomment-879359840 -->
+    <Content Include="qt-runtime-linux/**/*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <PackagePath>content/qt-runtime-linux</PackagePath>
+    </Content>
+  </ItemGroup>
 
   <!-- doesn't work - file included in package does not have the change -->
   <Target Name="PrepQmlForPacking" AfterTargets="PublishBuild" BeforeTargets="GenerateNuspec">

--- a/Hammer.csproj
+++ b/Hammer.csproj
@@ -127,11 +127,6 @@
     <None Include="assets/hammer-logo.png" Pack="true" PackagePath="\"/>
     <None Update="assets/fonts/RobotoCondensed-Regular.ttf" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <None Update="RobotoMono-Regular.ttf" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
-
-    <!-- better to use our own instead of the nuget package, see https://github.com/qmlnet/qmlnet/issues/241#issuecomment-879359840 -->
-    <None Update="qt-runtime-linux/**/*.*" CopyToOutputDirectory="PreserveNewest" />
-    <None Update="qt-runtime-osx/**/*.*" CopyToOutputDirectory="PreserveNewest" />
-    <None Update="qt-runtime-win/**/*.*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <!-- doesn't work - file included in package does not have the change -->

--- a/Hammer.csproj
+++ b/Hammer.csproj
@@ -130,6 +130,10 @@
     <Content Include="RobotoMono-Regular.ttf" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <Content Include="qt-runtime/**/*.*">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </Content>
+
   <!-- doesn't work - file included in package does not have the change -->
   <Target Name="PrepQmlForPacking" AfterTargets="PublishBuild" BeforeTargets="GenerateNuspec">
     <Exec Command="sed -i 's|// import appmodel 1.0|import appmodel 1.0|g' $(PublishDir)/Main.qml" />

--- a/Program.cs
+++ b/Program.cs
@@ -1249,20 +1249,9 @@ class Program
 
     static int Main(string[] args)
     {
+        // support searching multiple locations in case more are needed in the future. Originally added for nuget,
+        // but getting the Qt runtime into nuget is an issue
         List<string> qtRuntimes = new List<string>{ Path.Combine(AppModel.Extensions.GetApplicationLocation(), "qt-runtime") };
-
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-        {
-            qtRuntimes.Add(Path.Combine(AppModel.Extensions.GetApplicationLocation(), "qt-runtime-linux"));
-        }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            qtRuntimes.Add(Path.Combine(AppModel.Extensions.GetApplicationLocation(), "qt-runtime-osx"));
-        }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            qtRuntimes.Add(Path.Combine(AppModel.Extensions.GetApplicationLocation(), "qt-runtime-win"));
-        }
 
         var foundRuntime = false;
         foreach (var runtime in qtRuntimes)
@@ -1277,7 +1266,9 @@ class Program
 
         if (!foundRuntime)
         {
-            Console.WriteLine($"Using a default Qt runtime, none found in:\n  {string.Join("\n  ", qtRuntimes)}");
+            if (string.IsNullOrEmpty(RuntimeManager.FindSuitableQtRuntime())) {
+                Console.WriteLine($"Performing first-time setup, this'll take a couple of minutes...");
+            }
             RuntimeManager.DiscoverOrDownloadSuitableQtRuntime();
         }
 

--- a/Program.cs
+++ b/Program.cs
@@ -1269,6 +1269,7 @@ class Program
             if (string.IsNullOrEmpty(RuntimeManager.FindSuitableQtRuntime())) {
                 Console.WriteLine($"Performing first-time setup, this'll take a couple of minutes...");
             }
+            // downloaded to ~/.qmlnet-qt-runtimes by default
             RuntimeManager.DiscoverOrDownloadSuitableQtRuntime();
         }
 

--- a/Program.cs
+++ b/Program.cs
@@ -1249,15 +1249,35 @@ class Program
 
     static int Main(string[] args)
     {
-        var qtRuntime = Path.Combine(AppModel.Extensions.GetApplicationLocation(), "qt-runtime");
-        if (Directory.Exists(qtRuntime))
+        List<string> qtRuntimes = new List<string>{ Path.Combine(AppModel.Extensions.GetApplicationLocation(), "qt-runtime") };
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            Console.WriteLine($"Using embedded Qt runtime from {qtRuntime}");
-            RuntimeManager.ConfigureRuntimeDirectory(qtRuntime);
+            qtRuntimes.Add(Path.Combine(AppModel.Extensions.GetApplicationLocation(), "qt-runtime-linux"));
         }
-        else
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            Console.WriteLine($"Qt runtime not present in {qtRuntime}, using a default one");
+            qtRuntimes.Add(Path.Combine(AppModel.Extensions.GetApplicationLocation(), "qt-runtime-osx"));
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            qtRuntimes.Add(Path.Combine(AppModel.Extensions.GetApplicationLocation(), "qt-runtime-win"));
+        }
+
+        var foundRuntime = false;
+        foreach (var runtime in qtRuntimes)
+        {
+            if (Directory.Exists(runtime))
+            {
+                Console.WriteLine($"Using embedded Qt runtime from {runtime}");
+                RuntimeManager.ConfigureRuntimeDirectory(runtime);
+                foundRuntime = true;
+            }
+        }
+
+        if (!foundRuntime)
+        {
+            Console.WriteLine($"Using a default Qt runtime, none found in:\n  {string.Join("\n  ", qtRuntimes)}");
             RuntimeManager.DiscoverOrDownloadSuitableQtRuntime();
         }
 

--- a/create-package.sh
+++ b/create-package.sh
@@ -1,22 +1,26 @@
 #!/usr/bin/env bash
 
 set -e
-
-buildname='windows'
 qt_version='5.15.1-7fc8b10'
 dotnet_platform='win-x64'
+buildnames=(win osx linux)
 
 sed -i 's|// import appmodel 1.0|import appmodel 1.0|g' Main.qml
 echo "Prepared Main.qml for packaging"
 
-if [ ! -d qt-runtime ]; then
-  if [ ! -e qt-runtime.tar.gz ]; then
-    curl --location --output qt-runtime.tar.gz "https://github.com/qmlnet/qt-runtimes/releases/download/releases/qt-${qt_version}-${dotnet_platform}-runtime.tar.gz"
+for i in "${buildnames[@]}"
+do
+  if [ ! -d "qt-runtime-$i" ]; then
+    if [ ! -e "qt-runtime-$i.tar.gz" ]; then
+      echo "download https://github.com/qmlnet/qt-runtimes/releases/download/releases/qt-${qt_version}-${i}-x64-runtime.tar.gz"
+      curl --location --output "qt-runtime-$i.tar.gz" "https://github.com/qmlnet/qt-runtimes/releases/download/releases/qt-${qt_version}-${i}-x64-runtime.tar.gz"
+    fi
+    mkdir -p "qt-runtime-$i/"
+    tar -xf "qt-runtime-$i.tar.gz" -C "qt-runtime-$i/"
   fi
-  mkdir -p qt-runtime/
-  tar -xf qt-runtime.tar.gz -C qt-runtime/
-fi
-echo "Qt runtime downloaded & unpacked"
+done
+
+echo "Qt runtimes downloaded & unpacked"
 
 dotnet pack
 echo "Created package"

--- a/create-package.sh
+++ b/create-package.sh
@@ -1,26 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-qt_version='5.15.1-7fc8b10'
-dotnet_platform='win-x64'
-buildnames=(win osx linux)
-
 sed -i 's|// import appmodel 1.0|import appmodel 1.0|g' Main.qml
-echo "Prepared Main.qml for packaging"
-
-for i in "${buildnames[@]}"
-do
-  if [ ! -d "qt-runtime-$i" ]; then
-    if [ ! -e "qt-runtime-$i.tar.gz" ]; then
-      echo "Downloading https://github.com/qmlnet/qt-runtimes/releases/download/releases/qt-${qt_version}-${i}-x64-runtime.tar.gz..."
-      curl --location --output "qt-runtime-$i.tar.gz" "https://github.com/qmlnet/qt-runtimes/releases/download/releases/qt-${qt_version}-${i}-x64-runtime.tar.gz"
-    fi
-    mkdir -p "qt-runtime-$i/"
-    tar -xf "qt-runtime-$i.tar.gz" -C "qt-runtime-$i/"
-  fi
-done
-
-echo "Qt runtimes downloaded & unpacked"
 
 dotnet pack
 echo "Created package"

--- a/create-package.sh
+++ b/create-package.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+sed -i 's|// import appmodel 1.0|import appmodel 1.0|g' Main.qml
+echo "Prepared file for packaging"
+
+dotnet pack
+echo "Created package"
+
+sed -i 's|import appmodel 1.0|// import appmodel 1.0|g' Main.qml
+echo "Revesed Main.qml changes"
+
+echo "Done!"

--- a/create-package.sh
+++ b/create-package.sh
@@ -1,7 +1,22 @@
 #!/usr/bin/env bash
 
+set -e
+
+buildname='windows'
+qt_version='5.15.1-7fc8b10'
+dotnet_platform='win-x64'
+
 sed -i 's|// import appmodel 1.0|import appmodel 1.0|g' Main.qml
-echo "Prepared file for packaging"
+echo "Prepared Main.qml for packaging"
+
+if [ ! -d qt-runtime ]; then
+  if [ ! -e qt-runtime.tar.gz ]; then
+    curl --location --output qt-runtime.tar.gz "https://github.com/qmlnet/qt-runtimes/releases/download/releases/qt-${qt_version}-${dotnet_platform}-runtime.tar.gz"
+  fi
+  mkdir -p qt-runtime/
+  tar -xf qt-runtime.tar.gz -C qt-runtime/
+fi
+echo "Qt runtime downloaded & unpacked"
 
 dotnet pack
 echo "Created package"

--- a/create-package.sh
+++ b/create-package.sh
@@ -12,7 +12,7 @@ for i in "${buildnames[@]}"
 do
   if [ ! -d "qt-runtime-$i" ]; then
     if [ ! -e "qt-runtime-$i.tar.gz" ]; then
-      echo "download https://github.com/qmlnet/qt-runtimes/releases/download/releases/qt-${qt_version}-${i}-x64-runtime.tar.gz"
+      echo "Downloading https://github.com/qmlnet/qt-runtimes/releases/download/releases/qt-${qt_version}-${i}-x64-runtime.tar.gz..."
       curl --location --output "qt-runtime-$i.tar.gz" "https://github.com/qmlnet/qt-runtimes/releases/download/releases/qt-${qt_version}-${i}-x64-runtime.tar.gz"
     fi
     mkdir -p "qt-runtime-$i/"


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Adds the ability to install hammer via `dotnet tool install -g hammer`
#### Motivation for adding to Hammer
Easier install of Hammer in certain enterprise environments
#### Other info (issues closed, discussion etc)
Close https://github.com/health-validator/Hammer/issues/404