### PR TITLE
Upload pre-releases to nuget

### DIFF
--- a/.github/workflows/build-hammer.yml
+++ b/.github/workflows/build-hammer.yml
@@ -142,27 +142,21 @@ jobs:
         name: hammer-${{matrix.buildname}}
         path: publish/*
 
-    - name: Update version number file
-      shell: powershell
-      run: |
-        $csproj = "Hammer.csproj"
-        $regex = '<Version>(.+?)<\/Version>'
-        $replacement = "<Version>$1-rc</Version>"
-        (Get-Content $csproj -Raw) -replace $regex, $replacement | Set-Content $csproj
-
-    - name: Setup tmate session
-      if: runner.os == 'windows'
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 15
-
-    - name: Publish pre-release to nuget
+    # We only need to run this on one OS - so run it on the quickest one
+    - name: (Linux) Publish pre-release to nuget
+      if: runner.os == 'Linux'
       env:
         NUGET_API_KEY: ${{secrets.NUGET_API_KEY}}
       shell: bash
       run:
-        ./create-package.sh
-        dotnet nuget push nupkg/Hammer.${{env.SHORT_TAG_NAME}}.nupkg --api-key ${{env.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+        dotnet pack dotnet pack --version-suffix rc
+        # dotnet nuget push nupkg/Hammer.${{env.SHORT_TAG_NAME}}.nupkg --api-key ${{env.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
 
+    - name: Setup tmate session
+      if: runner.os == 'Linux'
+      if: runner.os == 'windows'
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 15
 
   upload_artifacts:
     name: Upload to pre-release

--- a/.github/workflows/build-hammer.yml
+++ b/.github/workflows/build-hammer.yml
@@ -153,12 +153,6 @@ jobs:
         dotnet pack
         dotnet nuget push nupkg/Hammer.*.nupkg --api-key ${{env.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
 
-    - name: Setup tmate session
-      if: runner.os == 'Linux'
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 15
-      env:
-        NUGET_API_KEY: ${{secrets.NUGET_API_KEY}}
 
   upload_artifacts:
     name: Upload to pre-release

--- a/.github/workflows/build-hammer.yml
+++ b/.github/workflows/build-hammer.yml
@@ -148,7 +148,7 @@ jobs:
       env:
         NUGET_API_KEY: ${{secrets.NUGET_API_KEY}}
       shell: bash
-      run:
+      run: |
         sed -i -r 's|<Version>(.+?)<\/Version>|<Version>\1-rc</Version>|g' Hammer.csproj
         dotnet pack
         dotnet nuget push nupkg/Hammer.*.nupkg --api-key ${{env.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
@@ -157,6 +157,8 @@ jobs:
       if: runner.os == 'Linux'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 15
+      env:
+        NUGET_API_KEY: ${{secrets.NUGET_API_KEY}}
 
   upload_artifacts:
     name: Upload to pre-release

--- a/.github/workflows/build-hammer.yml
+++ b/.github/workflows/build-hammer.yml
@@ -136,11 +136,32 @@ jobs:
       shell: bash
       run: cd bin/Release/${{matrix.dotnet-version}}/${{matrix.dotnet-platform}}/publish/ && 7z a -tzip $GITHUB_WORKSPACE/publish/Hammer-${{matrix.deployment-platform}}.zip
 
-    - name: Upload artifact
+    - name: Upload as a Github artifact
       uses: actions/upload-artifact@v2
       with:
         name: hammer-${{matrix.buildname}}
         path: publish/*
+
+    - name: Update version number file
+      shell: powershell
+      run: |
+        $csproj = "Hammer.csproj"
+        $regex = '<Version>(.+?)<\/Version>'
+        $replacement = "<Version>$1-rc</Version>"
+        (Get-Content $csproj -Raw) -replace $regex, $replacement | Set-Content $csproj
+
+    - name: Setup tmate session
+      if: runner.os == 'windows'
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 15
+
+    - name: Publish pre-release to nuget
+      env:
+        NUGET_API_KEY: ${{secrets.NUGET_API_KEY}}
+      shell: bash
+      run:
+        ./create-package.sh
+        dotnet nuget push nupkg/Hammer.${{env.SHORT_TAG_NAME}}.nupkg --api-key ${{env.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
 
 
   upload_artifacts:
@@ -165,6 +186,7 @@ jobs:
           artifacts/hammer-linux/Hammer-linux.zip
           artifacts/hammer-windows/Hammer-windows.zip
           artifacts/hammer-macos/Hammer-macos.zip
+
 
   validate_examples_metadata:
     name: Validate examples metadata file

--- a/.github/workflows/build-hammer.yml
+++ b/.github/workflows/build-hammer.yml
@@ -149,7 +149,7 @@ jobs:
         NUGET_API_KEY: ${{secrets.NUGET_API_KEY}}
       shell: bash
       run: |
-        sed -i -r 's|<Version>(.+?)<\/Version>|<Version>\1-rc</Version>|g' Hammer.csproj
+        sed -i -r 's|<Version>(.+?)<\/Version>|<Version>0.0.1-rc</Version>|g' Hammer.csproj
         dotnet pack
         dotnet nuget push nupkg/Hammer.*.nupkg --api-key ${{env.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
 

--- a/.github/workflows/build-hammer.yml
+++ b/.github/workflows/build-hammer.yml
@@ -149,7 +149,7 @@ jobs:
         NUGET_API_KEY: ${{secrets.NUGET_API_KEY}}
       shell: bash
       run:
-        dotnet pack dotnet pack --version-suffix rc
+        dotnet pack --version-suffix rc
         # dotnet nuget push nupkg/Hammer.${{env.SHORT_TAG_NAME}}.nupkg --api-key ${{env.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
 
     - name: Setup tmate session

--- a/.github/workflows/build-hammer.yml
+++ b/.github/workflows/build-hammer.yml
@@ -154,7 +154,6 @@ jobs:
 
     - name: Setup tmate session
       if: runner.os == 'Linux'
-      if: runner.os == 'windows'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 15
 

--- a/.github/workflows/build-hammer.yml
+++ b/.github/workflows/build-hammer.yml
@@ -142,6 +142,15 @@ jobs:
         name: hammer-${{matrix.buildname}}
         path: publish/*
 
+    - name: (Linux) Update version number file
+      if: runner.os == 'linux'
+      shell: powershell
+      run: |
+        $csproj = "Hammer.csproj"
+        $regex = '<Version>(.+?)<\/Version>'
+        $replacement = "<Version>$1-rc</Version>"
+        (Get-Content $csproj -Raw) -replace $regex, $replacement | Set-Content $csproj
+
     # We only need to run this on one OS - so run it on the quickest one
     - name: (Linux) Publish pre-release to nuget
       if: runner.os == 'Linux'
@@ -149,7 +158,7 @@ jobs:
         NUGET_API_KEY: ${{secrets.NUGET_API_KEY}}
       shell: bash
       run:
-        dotnet pack --version-suffix rc
+        dotnet pack dotnet pack
         # dotnet nuget push nupkg/Hammer.${{env.SHORT_TAG_NAME}}.nupkg --api-key ${{env.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
 
     - name: Setup tmate session

--- a/.github/workflows/build-hammer.yml
+++ b/.github/workflows/build-hammer.yml
@@ -142,15 +142,6 @@ jobs:
         name: hammer-${{matrix.buildname}}
         path: publish/*
 
-    - name: (Linux) Update version number file
-      if: runner.os == 'linux'
-      shell: powershell
-      run: |
-        $csproj = "Hammer.csproj"
-        $regex = '<Version>(.+?)<\/Version>'
-        $replacement = "<Version>$1-rc</Version>"
-        (Get-Content $csproj -Raw) -replace $regex, $replacement | Set-Content $csproj
-
     # We only need to run this on one OS - so run it on the quickest one
     - name: (Linux) Publish pre-release to nuget
       if: runner.os == 'Linux'
@@ -158,7 +149,7 @@ jobs:
         NUGET_API_KEY: ${{secrets.NUGET_API_KEY}}
       shell: bash
       run:
-        dotnet pack dotnet pack
+        dotnet pack /property:VersionSuffix=rc
         # dotnet nuget push nupkg/Hammer.${{env.SHORT_TAG_NAME}}.nupkg --api-key ${{env.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
 
     - name: Setup tmate session

--- a/.github/workflows/build-hammer.yml
+++ b/.github/workflows/build-hammer.yml
@@ -149,8 +149,9 @@ jobs:
         NUGET_API_KEY: ${{secrets.NUGET_API_KEY}}
       shell: bash
       run:
-        dotnet pack /property:VersionSuffix=rc
-        # dotnet nuget push nupkg/Hammer.${{env.SHORT_TAG_NAME}}.nupkg --api-key ${{env.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+        sed -i -r 's|<Version>(.+?)<\/Version>|<Version>\1-rc</Version>|g' Hammer.csproj
+        dotnet pack
+        dotnet nuget push nupkg/Hammer.*.nupkg --api-key ${{env.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
 
     - name: Setup tmate session
       if: runner.os == 'Linux'


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Upload pre-releases to nuget
#### Motivation for adding to Hammer
So a tester can easily following along with the latest pre-release version without having to manually download & install all the time.
#### Other info (issues closed, discussion etc)
Available to install always as `dotnet tool install -g hammer --version 0.0.1-rc` (when it works https://github.com/NuGet/Home/issues/11153).