### PR TITLE
Add option to control terminology server

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -469,7 +469,8 @@ class Program
 
         private bool terminologyDisabled()
         {
-            return TerminologyService == "don't check with any server";
+            string[] disabledTerminology = {"don't check with any server", "n/a", "off", "none"};
+            return disabledTerminology.Contains(TerminologyService, StringComparer.OrdinalIgnoreCase);
         }
 
         private string getJavaTxString()

--- a/SettingsPane.qml
+++ b/SettingsPane.qml
@@ -95,6 +95,9 @@ Pane {
                     model.append({text: editText})
                 }
             }
+            onActivated: {
+                appmodel.terminologyService = currentText
+            }
             Layout.fillWidth: true; Layout.columnSpan: 3
         }
 

--- a/SettingsPane.qml
+++ b/SettingsPane.qml
@@ -86,7 +86,7 @@ Pane {
             model: ListModel {
                 id: model
                 ListElement { text: "https://tx.fhir.org" }
-                ListElement { text: qsTr("don't check with any server") }
+                ListElement { text: "don't check with any server" }
             }
             onAccepted: {
                 appmodel.terminologyService = currentText

--- a/SettingsPane.qml
+++ b/SettingsPane.qml
@@ -73,6 +73,32 @@ Pane {
         }
 
         Text {
+            text: qsTr("Check terminologies with")
+            color: Universal.foreground
+            font.pointSize: settingsPane.headerFontSize
+            font.bold: true
+            Layout.fillWidth: true; Layout.columnSpan: 3
+            topPadding: 10
+        }
+        ComboBox {
+            id: terminologyCombobox
+            editable: true
+            model: ListModel {
+                id: model
+                ListElement { text: "https://tx.fhir.org" }
+                ListElement { text: qsTr("don't check with any server") }
+            }
+            onAccepted: {
+                appmodel.terminologyService = currentText
+
+                if (find(editText) === -1) {
+                    model.append({text: editText})
+                }
+            }
+            Layout.fillWidth: true; Layout.columnSpan: 3
+        }
+
+        Text {
             text: qsTr("Show errors and...")
             color: Universal.foreground
             font.pointSize: settingsPane.headerFontSize


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add options to control or disable use of a terminology server.
#### Motivation for adding to Hammer
So the app can work offline as needed.
#### Other info (issues closed, discussion etc)
Close https://github.com/health-validator/Hammer/issues/8.